### PR TITLE
Add minimal random video chat demo

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,16 +14,55 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public/index.html'));
 });
 
+// In-memory waiting queue and partner map
+const waiting = [];
+const partners = new Map();
+
 io.on('connection', socket => {
   console.log('New client connected:', socket.id);
 
-  // Example: relay signaling messages
+  // A client requests to find a partner
+  socket.on('join', () => {
+    if (waiting.length > 0) {
+      const other = waiting.shift();
+      partners.set(socket.id, other.id);
+      partners.set(other.id, socket.id);
+      socket.emit('match', { id: other.id, initiator: false });
+      other.emit('match', { id: socket.id, initiator: true });
+    } else {
+      waiting.push(socket);
+    }
+  });
+
+  // Relay signaling messages between paired clients
   socket.on('signal', ({ to, data }) => {
     io.to(to).emit('signal', { from: socket.id, data });
   });
 
+  // Leaving the current chat (e.g., skip/next)
+  socket.on('leave', () => {
+    const partnerId = partners.get(socket.id);
+    if (partnerId) {
+      io.to(partnerId).emit('partner-left');
+      partners.delete(partnerId);
+      partners.delete(socket.id);
+    } else {
+      const idx = waiting.findIndex(s => s.id === socket.id);
+      if (idx !== -1) waiting.splice(idx, 1);
+    }
+  });
+
   socket.on('disconnect', () => {
     console.log('Client disconnected:', socket.id);
+    const partnerId = partners.get(socket.id);
+    if (partnerId) {
+      io.to(partnerId).emit('partner-left');
+      partners.delete(partnerId);
+      partners.delete(socket.id);
+    } else {
+      const idx = waiting.findIndex(s => s.id === socket.id);
+      if (idx !== -1) waiting.splice(idx, 1);
+    }
   });
 });
 

--- a/public/client.js
+++ b/public/client.js
@@ -1,0 +1,85 @@
+const socket = io();
+const localVideo = document.getElementById('localVideo');
+const remoteVideo = document.getElementById('remoteVideo');
+const startBtn = document.getElementById('startBtn');
+const status = document.getElementById('status');
+
+let localStream;
+let pc;
+let partnerId;
+
+async function initMedia() {
+  try {
+    localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+    localVideo.srcObject = localStream;
+  } catch (err) {
+    console.error('Media error:', err);
+    status.textContent = 'Could not access camera/mic.';
+  }
+}
+
+initMedia();
+
+startBtn.onclick = () => {
+  socket.emit('leave');
+  cleanup();
+  socket.emit('join');
+  status.textContent = 'Looking for a partner...';
+};
+
+function startConnection(initiator) {
+  pc = new RTCPeerConnection({
+    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+  });
+  localStream.getTracks().forEach(t => pc.addTrack(t, localStream));
+
+  pc.onicecandidate = ({ candidate }) => {
+    if (candidate) socket.emit('signal', { to: partnerId, data: { candidate } });
+  };
+  pc.ontrack = ({ streams: [stream] }) => {
+    remoteVideo.srcObject = stream;
+  };
+  pc.onconnectionstatechange = () => {
+    if (pc.connectionState === 'connected') status.textContent = 'Connected!';
+  };
+
+  if (initiator) {
+    pc.createOffer().then(o => pc.setLocalDescription(o)).then(() => {
+      socket.emit('signal', { to: partnerId, data: { description: pc.localDescription } });
+    });
+  }
+}
+
+socket.on('match', ({ id, initiator }) => {
+  partnerId = id;
+  status.textContent = 'Partner found! Connecting...';
+  startConnection(initiator);
+});
+
+socket.on('signal', async ({ from, data }) => {
+  if (from !== partnerId) return;
+  if (data.description) {
+    await pc.setRemoteDescription(data.description);
+    if (data.description.type === 'offer') {
+      const answer = await pc.createAnswer();
+      await pc.setLocalDescription(answer);
+      socket.emit('signal', { to: partnerId, data: { description: pc.localDescription } });
+    }
+  } else if (data.candidate) {
+    try { await pc.addIceCandidate(data.candidate); } catch (e) { console.error(e); }
+  }
+});
+
+socket.on('partner-left', () => {
+  status.textContent = 'Partner disconnected.';
+  cleanup();
+});
+
+function cleanup() {
+  if (pc) {
+    pc.close();
+    pc = null;
+  }
+  remoteVideo.srcObject = null;
+  partnerId = null;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -3,29 +3,22 @@
 <head>
   <meta charset="utf-8">
   <title>Random Video Chat</title>
+  <style>
+    body { font-family: sans-serif; text-align: center; }
+    video { width: 45%; max-width: 300px; background: #000; margin: 5px; }
+    #videos { display: flex; justify-content: center; flex-wrap: wrap; }
+  </style>
 </head>
 <body>
-  <h1>🚀 Video-chat server is up!</h1>
-  <p>Open your browser console to see signaling logs.</p>
+  <h1>Random Video Chat</h1>
+  <div id="videos">
+    <video id="localVideo" autoplay playsinline muted></video>
+    <video id="remoteVideo" autoplay playsinline></video>
+  </div>
+  <button id="startBtn">Start / Next</button>
+  <p id="status"></p>
 
   <script src="/socket.io/socket.io.js"></script>
-  <script>
-    const socket = io();
-
-    socket.on('connect', () => {
-      console.log('Connected to signaling server as', socket.id);
-    });
-
-    // Example: listen for relayed signals
-    socket.on('signal', ({ from, data }) => {
-      console.log('Signal from', from, data);
-    });
-
-    // For testing: send a dummy signal after 3s
-    setTimeout(() => {
-      console.log('Sending test signal to self');
-      socket.emit('signal', { to: socket.id, data: { msg: 'hello!' } });
-    }, 3000);
-  </script>
+  <script src="client.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement a small queue-based matchmaking server
- add basic front-end with local/remote video and start button
- implement WebRTC logic in `client.js`

## Testing
- `npm install`
- `npm start` *(server started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68688cd0ba6c8322a50e837ad09968cf